### PR TITLE
Fixed out-of-bounds vector access

### DIFF
--- a/bfxr.h
+++ b/bfxr.h
@@ -1292,10 +1292,10 @@ namespace bfxr
         _flangerDeltaOffset = p.flangerSweep * p.flangerSweep * p.flangerSweep * 0.2;
         _flangerPos = 0;
 
-        _flangerBuffer.reserve(1024);
-        _noiseBuffer.reserve(32);
-        _pinkNoiseBuffer.reserve(32);
-        _loResNoiseBuffer.reserve(32);
+        _flangerBuffer.resize(1024);
+        _noiseBuffer.resize(32);
+        _pinkNoiseBuffer.resize(32);
+        _loResNoiseBuffer.resize(32);
 
         _oneBitNoiseState = 1 << 14;
         _oneBitNoise = 0;


### PR DESCRIPTION
`vector::reserve()` will allocate memory but will not increase the capacity of the array. Thus, we should use `resize()` instead.

How to reproduce the error: click on the "Play sound" button.

---

Note: the app still crashes for other reason(s).

I found the `SynthSample()` method is also accessing out-of-bounds, possibly because `sample_length` gets out of sync with `samples.size()`, as they seem to exist on different objects.