### PR TITLE
Fixed another out-of-bounds vector access

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -250,7 +250,7 @@ class AppBase
   Draw() = 0;
 
   virtual float
-  SynthSample(int time) = 0;
+  SynthSample(unsigned int time) = 0;
 
   void
   OnRender()
@@ -329,8 +329,8 @@ class AppBase
   }
 
  protected:
-  int sample_position     = 0;
-  int sample_length = 0;
+  unsigned int sample_position     = 0;
+  unsigned int sample_length = 0;
   int   sample_frequency    = 44100;
   float audio_callback_time = 0;
   int   samples_consumed    = 0;
@@ -495,9 +495,9 @@ class App : public AppBase
   std::vector<double> samples;
 
   float
-  SynthSample(int time) override
+  SynthSample(unsigned int time) override
   {
-    if(samples.empty()) { return 0.0f; }
+    if(time >= samples.size()) { return 0.0f; }
     else return samples[time];
   }
 };


### PR DESCRIPTION
This was crashing whenever the user tried to play sounds too quickly. It's likely that `sample_length` got out of sync with `samples.size()`, as they live in separate objects.

I've also changed those variables to `unsigned` to avoid a warning about comparing integer expressions of different signedness.